### PR TITLE
Fetch should be able to pick up none encrypted files too

### DIFF
--- a/fetch.sh
+++ b/fetch.sh
@@ -2,4 +2,4 @@
 source .env
 set -euv
 
-sftp -i $SSH_KEY_FILE $SFTP_USER@$SFTP_HOST:$SFTP_DIR/*.gpg ./incoming/
+sftp -i $SSH_KEY_FILE $SFTP_USER@$SFTP_HOST:$SFTP_DIR/*.* ./incoming/


### PR DESCRIPTION
For wider reuse the fetch should be able to pick up any files from a sftp pickup point. GPG encryption is optional.

Is there any nicer way to pick up all files other than *.*? :)

Alternatively, could this be something configurable in .env via a boolean (ENCRYPTED=True)?